### PR TITLE
Fix typo trace-usage.c

### DIFF
--- a/trace-usage.c
+++ b/trace-usage.c
@@ -24,7 +24,7 @@ static struct usage_help usage_help[] = {
 		"          -p run command with plugin enabled\n"
 		"          -F filter only on the given process\n"
 		"          -P trace the given pid like -F for the command\n"
-		"          -c also trace the childen of -F or -P\n"
+		"          -c also trace the children of -F or -P\n"
 		"          -T do a stacktrace on all events\n"
 		"          -l filter function name\n"
 		"          -g set graph function\n"


### PR DESCRIPTION
Change `childen` to `children`