### PR TITLE
fix tracecmd.py

### DIFF
--- a/python/tracecmd.py
+++ b/python/tracecmd.py
@@ -88,7 +88,7 @@ class Event(object, DictMixin):
 
     @cached_property
     def name(self):
-        return event_format_name_get(self._format)
+        return tep_event_name_get(self._format)
 
     @cached_property
     def pid(self):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "tracecmd.py", line 251, in <module>
    print("\t%s" % (ev))
  File "tracecmd.py", line 66, in __str__
    (self.ts/1000000000, self.ts%1000000000, self.cpu, self.name,
  File "tracecmd.py", line 46, in _get
    value = func(self)
  File "tracecmd.py", line 91, in name
    return event_format_name_get(self._format)
NameError: global name 'event_format_name_get' is not defined
```