### PR TITLE
arm-linux-gnueabi-gcc unable to link against rt

### DIFF
--- a/tracecmd/Makefile
+++ b/tracecmd/Makefile
@@ -43,7 +43,7 @@ all_objs := $(sort $(ALL_OBJS))
 all_deps := $(all_objs:$(bdir)/%.o=$(bdir)/.%.d)
 
 CONFIG_INCLUDES =
-CONFIG_LIBS	= -lrt
+CONFIG_LIBS	= 
 CONFIG_FLAGS	=
 
 all: $(TARGETS)


### PR DESCRIPTION
Whilst building trace-cmd for a 32bit android board I was running into problems of my toolchain (arm-linux-gnueabi-) not being able to link rt. Removing the link the build succeeds, I do not know enough about the project to know if this is a valid fix, but it should be brought to light the cross compiling is not possible with the rt link using standard repository toolchains.