### PR TITLE
Hack fix for CROSS_COMPILE not being passed to tracecmd/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ endef
 $(call allow-override,CC,$(CROSS_COMPILE)gcc)
 $(call allow-override,AR,$(CROSS_COMPILE)ar)
 
+MAKE:=$(MAKE) CC=$(CC)
+
 EXT = -std=gnu99
 INSTALL = install
 


### PR DESCRIPTION
When cross compiling trace-cmd the tracecmd/Makefile is not being passed the toolchain passed to the parent Makefile via CROSS_COMPILE.