### PR TITLE
tracecmd: add NO_LIBZSTD option to disable libzstd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,7 @@ endif
 
 export ZLIB_LDLAGS
 
+ifndef NO_LIBZSTD
 TEST_LIBZSTD = $(shell sh -c "$(PKG_CONFIG) --atleast-version 1.4.0 libzstd > /dev/null 2>&1 && echo y")
 
 ifeq ("$(TEST_LIBZSTD)", "y")
@@ -338,6 +339,7 @@ $(info	  *************************************************************)
 endif
 
 export LIBZSTD_CFLAGS LIBZSTD_LDLAGS ZSTD_INSTALLED
+endif
 
 CUNIT_INSTALLED := $(shell if (printf "$(pound)include <CUnit/Basic.h>\n void main(){CU_initialize_registry();}" | $(CC) -o /dev/null -x c - -lcunit >/dev/null 2>&1) ; then echo 1; else echo 0 ; fi)
 export CUNIT_INSTALLED


### PR DESCRIPTION
Other Linux kernel tools like perf already include options to disable
libzstd manually. Add this option also to trace-cmd.

The OpenWrt SDK fails to build trace-cmd due to the autodetection of
libzstd. The package is present in some feed repositories but should
not be used by trace-cmd. The compilation will fail with:

  Package trace-cmd is missing dependencies for the following libraries:
  libzstd.so.1

Signed-off-by: Nick Hainke <vincent@systemli.org>