### PR TITLE
trace-cmd record: Reset PATH variable after strtok search

### DIFF
--- a/tracecmd/trace-record.c
+++ b/tracecmd/trace-record.c
@@ -1708,6 +1708,14 @@ static void execute_program(int argc, char **argv)
 				break;
 
 		}
+
+		/*
+		 * reset PATH to saveptr, as strtok_r overwrites the string
+		 * returned by getenv() which backs the PATH environment
+		 * variable.
+		 */
+		if (setenv("PATH", saveptr, 1))
+			die("Failed to reset PATH to %s (%s)", saveptr, strerror(errno));
 	} else {
 		strncpy(buf, argv[0], sizeof(buf));
 	}


### PR DESCRIPTION
execute_program(), in the trace-cmd record subcommand, searches for a command in PATH to create an absolute path to pass to execve. The implementation uses strtok_r, which mutates the underlying string in place by replacing ':' tokens with NULL bytes. This can and does cause the PATH that's passed to execve to only contain the first entry to PATH, which can cause issues such as the following:

[root@maniforge linus]# trace-cmd record -e sched -v -e sched_stat_runtime make clean /bin/sh: line 1: uname: command not found
/bin/sh: line 1: sed: command not found
/bin/sh: line 1: head: command not found
/bin/sh: line 1: grep: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
make: gcc: No such file or directory
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
/bin/sh: line 1: mkdir: command not found
Makefile:681: arch//Makefile: No such file or directory make: *** No rule to make target 'arch//Makefile'.  Stop.

We should be resetting the PATH variable to the string stored in the saveptr argument to strtok_r.