### PR TITLE
fix error support clang

### DIFF
--- a/lib/trace-cmd/trace-hooks.c
+++ b/lib/trace-cmd/trace-hooks.c
@@ -11,7 +11,7 @@
 #include "trace-cmd-private.h"
 #include "trace-cmd-local.h"
 #include "event-utils.h"
-
+void warning(const char *fmt, ...); 
 struct hook_list *tracecmd_create_event_hook(const char *arg)
 {
 	struct hook_list *hook;

--- a/lib/trace-cmd/trace-input.c
+++ b/lib/trace-cmd/trace-input.c
@@ -34,7 +34,7 @@
 
 /* for debugging read instead of mmap */
 static int force_read = 0;
-
+void warning(const char *fmt, ...); 
 struct page_map {
 	struct list_head	list;
 	off_t			offset;

--- a/lib/trace-cmd/trace-msg.c
+++ b/lib/trace-cmd/trace-msg.c
@@ -42,7 +42,7 @@ typedef __be32 be32;
 #define MSG_MAX_DATA_LEN		(MSG_MAX_LEN - MSG_HDR_LEN)
 
 unsigned int page_size;
-
+void warning(const char *fmt, ...); 
 struct tracecmd_msg_tinit {
 	be32 cpus;
 	be32 page_size;

--- a/lib/trace-cmd/trace-output.c
+++ b/lib/trace-cmd/trace-output.c
@@ -29,7 +29,7 @@
 /* We can't depend on the host size for size_t, all must be 64 bit */
 typedef unsigned long long	tsize_t;
 typedef long long		stsize_t;
-
+void warning(const char *fmt, ...); 
 struct tracecmd_option {
 	unsigned short	id;
 	int		size;

--- a/lib/trace-cmd/trace-plugin.c
+++ b/lib/trace-cmd/trace-plugin.c
@@ -13,7 +13,7 @@
 #include "trace-cmd-local.h"
 
 #define LOCAL_PLUGIN_DIR ".local/lib/trace-cmd/plugins/"
-
+void warning(const char *fmt, ...); 
 struct trace_plugin_list {
 	struct trace_plugin_list	*next;
 	char				*name;

--- a/lib/trace-cmd/trace-recorder.c
+++ b/lib/trace-cmd/trace-recorder.c
@@ -29,7 +29,7 @@
 #endif
 
 #define POLL_TIMEOUT_MS		1000
-
+void warning(const char *fmt, ...); 
 struct tracecmd_recorder {
 	struct tracefs_cpu *tcpu;
 	int		fd;

--- a/lib/trace-cmd/trace-timesync.c
+++ b/lib/trace-cmd/trace-timesync.c
@@ -21,7 +21,7 @@
 #include "tracefs.h"
 #include "event-utils.h"
 #include "trace-tsync-local.h"
-
+void warning(const char *fmt, ...); 
 struct tsync_proto {
 	struct tsync_proto *next;
 	char proto_name[TRACECMD_TSYNC_PNAME_LENGTH];

--- a/lib/trace-cmd/trace-util.c
+++ b/lib/trace-cmd/trace-util.c
@@ -28,7 +28,7 @@
 
 #define LOCAL_PLUGIN_DIR ".trace-cmd/plugins"
 #define PROC_STACK_FILE "/proc/sys/kernel/stack_tracer_enabled"
-
+void warning(const char *fmt, ...); 
 static bool debug;
 static bool notimeout;
 static int log_level = TEP_LOG_WARNING;

--- a/tracecmd/trace-agent.c
+++ b/tracecmd/trace-agent.c
@@ -25,7 +25,7 @@
 #define GUEST_NAME	"::GUEST::"
 
 #define dprint(fmt, ...)	tracecmd_debug(fmt, ##__VA_ARGS__)
-
+void warning(const char *fmt, ...); 
 static void make_vsocks(int nr, int *fds, unsigned int *ports)
 {
 	unsigned int port;

--- a/tracecmd/trace-hist.c
+++ b/tracecmd/trace-hist.c
@@ -15,7 +15,7 @@
 #include "trace-hash-local.h"
 #include "trace-local.h"
 #include "list.h"
-
+void warning(const char *fmt, ...); 
 static int sched_wakeup_type;
 static int sched_wakeup_new_type;
 static int sched_switch_type;

--- a/tracecmd/trace-listen.c
+++ b/tracecmd/trace-listen.c
@@ -35,7 +35,7 @@
 #define VAR_RUN_DIR		VAR_DIR_Q(VAR_DIR) "/run"
 
 #define LISTEN_PIDFILE		"trace-cmd-net.pid"
-
+void warning(const char *fmt, ...); 
 static char *default_output_dir = ".";
 static char *output_dir;
 static char *default_output_file = "trace";

--- a/tracecmd/trace-profile.c
+++ b/tracecmd/trace-profile.c
@@ -32,7 +32,7 @@
 #define stack_from_item(item)	container_of(item, struct stack_data, hash)
 #define group_from_item(item)	container_of(item, struct group_data, hash)
 #define event_data_from_item(item)	container_of(item, struct event_data, hash)
-
+void warning(const char *fmt, ...); 
 static unsigned long long nsecs_per_sec(unsigned long long ts)
 {
 	return ts / NSEC_PER_SEC;

--- a/tracecmd/trace-read.c
+++ b/tracecmd/trace-read.c
@@ -24,7 +24,7 @@
 #include "trace-hash-local.h"
 #include "kbuffer.h"
 #include "list.h"
-
+void warning(const char *fmt, ...); 
 /*
  * tep_func_repeat_format is defined as a weak variable in the
  * libtraceevent library function plugin, to allow applications

--- a/tracecmd/trace-record.c
+++ b/tracecmd/trace-record.c
@@ -59,7 +59,7 @@
 #define TSC_CLOCK	"x86-tsc"
 
 #define dprint(fmt, ...)	tracecmd_debug(fmt, ##__VA_ARGS__)
-
+void warning(const char *fmt, ...); 
 enum trace_type {
 	TRACE_TYPE_RECORD	= 1,
 	TRACE_TYPE_START	= (1 << 1),

--- a/tracecmd/trace-restore.c
+++ b/tracecmd/trace-restore.c
@@ -20,7 +20,7 @@
 #include <errno.h>
 
 #include "trace-local.h"
-
+void warning(const char *fmt, ...); 
 static struct tracecmd_output *create_output(const char *file,
 					     const char *tracing_dir, const char *kallsyms)
 {

--- a/tracecmd/trace-stack.c
+++ b/tracecmd/trace-stack.c
@@ -19,7 +19,7 @@
 #include "trace-local.h"
 
 #define PROC_FILE "/proc/sys/kernel/stack_tracer_enabled"
-
+void warning(const char *fmt, ...); 
 enum stack_type {
 	STACK_START,
 	STACK_STOP,

--- a/tracecmd/trace-vm.c
+++ b/tracecmd/trace-vm.c
@@ -14,7 +14,7 @@
 
 #include "trace-local.h"
 #include "trace-msg.h"
-
+void warning(const char *fmt, ...); 
 static struct trace_guest *guests;
 static size_t guests_len;
 


### PR DESCRIPTION
I meet problems like this when I use clang:
[  109s] trace-hooks.c:135:5: error: call to undeclared function 'warning'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
[  109s]   135 |                                 warning("unknown flag %c\n", flags[i]);
[  109s]       |                                 ^
[  109s] trace-hooks.c:152:2: error: call to undeclared function 'warning'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
[  109s]   152 |         warning("Invalid hook format '%s'", arg);
[  109s]       |         ^
[  109s] 2 errors generated.
And after this problem is solved, this problem will also occur in other packages. I have added void warning(const char *fmt,...); in all packages where this problem occurs.
