### PR TITLE
fix a incorrect substitution

### DIFF
--- a/lib/trace-cmd/plugins/Makefile
+++ b/lib/trace-cmd/plugins/Makefile
@@ -30,7 +30,7 @@ $(DEPS): $(bdir)/.%.d: %.c
 
 $(PLUGIN_OBJS): $(bdir)/%.o : $(bdir)/.%.d
 
-PLUGINS_INSTALL = $(subst .so,.install,$(PLUGINS))
+PLUGINS_INSTALL = $(patsubst %.so,%.install,$(PLUGINS))
 
 $(PLUGINS_INSTALL): $(bdir)/%.install : $(bdir)/%.so force
 	$(Q)$(call do_install_data,$<,$(plugin_tracecmd_dir_SQ))


### PR DESCRIPTION
If you simply replace '.so' with '.install', the directory name of $(PLUGINS) will be changed to the wrong path name if it contains .so. (E.g, /home/jh.son/ -> /home/jh.installn/)
solved the problem by chaning the substitution function to patsubst.